### PR TITLE
Upgrade to being compatible with ActiveTriples 0.8.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,16 @@
 language: ruby
 bundler_args: --without debug
 script: "bundle exec rspec spec"
+sudo: false
+cache: bundler
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.0
-  - 2.1.1
-  - jruby-19mode
+ - 2.0
+ - 2.1
+ - 2.2.4
+ - 2.3.0
+ - jruby-9.0.4.0
+ - rbx-2
 matrix:
   allow_failures:
-      - rvm: jruby-19mode
+      - rvm: jruby-9.0.4.0
+      - rvm: rbx-2

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ script: "bundle exec rspec spec"
 sudo: false
 cache: bundler
 rvm:
- - 2.0
- - 2.1
  - 2.2.4
  - 2.3.0
  - jruby-9.0.4.0

--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,4 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in ld4l-works_rdf.gemspec
 gemspec
 
-gem 'active_triples-solrizer', :git => 'git@github.com:ActiveTriples/active_triples-solrizer.git', :branch => 'master'
+gem 'active_triples-solrizer', :github => 'ActiveTriples/active_triples-solrizer', :branch => 'master'

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in ld4l-works_rdf.gemspec
 gemspec
+
+gem 'active_triples-solrizer', :git => 'git@github.com:ActiveTriples/active_triples-solrizer.git', :branch => 'master'

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in ld4l-works_rdf.gemspec
 gemspec
-
-gem 'active_triples-solrizer', :github => 'ActiveTriples/active_triples-solrizer', :branch => 'master'

--- a/README.md
+++ b/README.md
@@ -163,3 +163,4 @@ Other ontologies may also be used that aren't listed.
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)
 5. Create a new Pull Request
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # LD4L::WorksRDF
 
+[![Build Status](https://travis-ci.org/ld4l/works_rdf.png?branch=master)](https://travis-ci.org/ld4l/works_rdf) 
+[![Coverage Status](https://coveralls.io/repos/ld4l/works_rdf/badge.png?branch=master)](https://coveralls.io/r/ld4l/works_rdf?branch=master)
+[![Gem Version](https://badge.fury.io/rb/ld4l-works_rdf.svg)](http://badge.fury.io/rb/ld4l-works_rdf)
+[![Dependency Status](https://www.versioneye.com/ruby/ld4l-works_rdf/0.0.4/badge.svg)](https://www.versioneye.com/ruby/ld4l-works_rdf/0.0.4)
+
+
 The primary purpose of this gem is the extraction of basic display metadata from rdf triples for use
 in a user interface.  It is assumed that if detailed metadata is required, the user will be redirected 
 back to the original source.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ that the code will work in a usable way outside of its use in LD4L Use Cases.
 
 ### Examples
 
+*Common setup for all examples
+```
+require 'ld4l/works_rdf'
+```
+
 If the ontology is unknown, you can try all known methods by calling the generic metadata extraction service.
 ```
 item_metadata = LD4L::WorksRDF::AttemptGenericMetadataExtraction.call(uri)
@@ -55,7 +60,7 @@ item_metadata = LD4L::WorksRDF::AttemptGenericMetadataExtraction.call(uri)
 
 If the URI is known to return marcxml, use the following service.
 ```
-item_metadata = LD4L::WorksRDF::GetMetadataFromMarcxml.call(uri)
+item_metadata = LD4L::WorksRDF::GetMetadataFromMarcxmlURI.call(uri)
 ```
 
 If the URI is known to return schema.org ontology as interpreted by oclc, use the following service.
@@ -163,4 +168,3 @@ Other ontologies may also be used that aren't listed.
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)
 5. Create a new Pull Request
-

--- a/ld4l-works_rdf.gemspec
+++ b/ld4l-works_rdf.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('rdf')
   spec.add_dependency('active-triples')
   spec.add_dependency('active_triples-local_name')
+  spec.add_dependency('active_triples-solrizer')
   spec.add_dependency('ld4l-foaf_rdf')
 
   spec.add_dependency('curb')

--- a/ld4l-works_rdf.gemspec
+++ b/ld4l-works_rdf.gemspec
@@ -17,21 +17,16 @@ Gem::Specification.new do |spec|
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  # spec.test_files    = `git ls-files -- {spec}/*`.split("\n")               # FROM ActiveTriples gemspec file
-  # spec.require_paths = ["lib"]                                              # NOT IN ActiveTriples gemspec file
 
-  #  spec.add_dependency('ffi', '~> 1.9.5')
-  spec.add_dependency('rdf', '~> 1.1')
-
-  spec.add_dependency('active-triples', '~> 0.5')
-  spec.add_dependency('active_triples-local_name', '~> 0.1')
-  spec.add_dependency('ld4l-foaf_rdf', '~> 0.0')
+  spec.add_dependency('rdf')
+  spec.add_dependency('active-triples')
+  spec.add_dependency('active_triples-local_name')
+  spec.add_dependency('ld4l-foaf_rdf')
 
   spec.add_dependency('curb')
 
   spec.add_development_dependency('pry')
-  spec.add_development_dependency('pry-byebug')    # Works with ruby > 2
-  # spec.add_development_dependency('pry-debugger')  # Works with ruby < 2
+  spec.add_development_dependency('pry-byebug')
   spec.add_development_dependency('rdoc')
   spec.add_development_dependency('rspec')
   spec.add_development_dependency('coveralls')

--- a/lib/ld4l/works_rdf.rb
+++ b/lib/ld4l/works_rdf.rb
@@ -1,6 +1,7 @@
 require 'rdf'
 require 'active_triples'
 require 'active_triples/local_name'
+require 'active_triples/solrizer'
 require 'curb'
 require	'linkeddata'
 require 'ld4l/works_rdf/vocab/bibo'
@@ -74,6 +75,7 @@ module LD4L
     autoload :GetMetadataFromVivoURI,      'ld4l/works_rdf/services/get_metadata_from_vivo_uri'
     autoload :GetMetadataFromOclcURI,      'ld4l/works_rdf/services/get_metadata_from_oclc_uri'
     autoload :AttemptGenericMetadataExtraction, 'ld4l/works_rdf/services/attempt_generic_metadata_extraction'
+    autoload :GetMetadataFromSolrQuery,    'ld4l/works_rdf/services/get_metadata_from_solr_query'
 
     autoload :GetModelFromURI,             'ld4l/works_rdf/services/get_model_from_uri'
 
@@ -86,6 +88,7 @@ module LD4L
     autoload :GetMetadataFromOclcModel,    'ld4l/works_rdf/services/metadata_services/get_metadata_from_oclc_model'
     autoload :GetMetadataFromVivoModel,    'ld4l/works_rdf/services/metadata_services/get_metadata_from_vivo_model'
     autoload :GetMetadataFromBiboModel,    'ld4l/works_rdf/services/metadata_services/get_metadata_from_bibo_model'
+    autoload :GetMetadataFromSolrDoc,      'ld4l/works_rdf/services/metadata_services/get_metadata_from_solr_doc'
     autoload :SetErrorInMetadata,          'ld4l/works_rdf/services/metadata_services/set_error_in_metadata'
 
     # autoload model service classes
@@ -98,6 +101,7 @@ module LD4L
     autoload :GetMarcxmlFromURI,           'ld4l/works_rdf/services/negotiation_services/get_marcxml_from_uri'
     autoload :GetTurtleFromURI,            'ld4l/works_rdf/services/negotiation_services/get_turtle_from_uri'
     autoload :GetRdfxmlFromURI,            'ld4l/works_rdf/services/negotiation_services/get_rdfxml_from_uri'
+    autoload :GetSolrResultsFromSolrQuery, 'ld4l/works_rdf/services/negotiation_services/get_solr_results_from_solr_query'
     autoload :ResponseHeader,              'ld4l/works_rdf/services/negotiation_services/response_header'
 
     # autoload repository service classes

--- a/lib/ld4l/works_rdf.rb
+++ b/lib/ld4l/works_rdf.rb
@@ -9,6 +9,7 @@ require 'ld4l/works_rdf/vocab/vitro'
 require 'ld4l/works_rdf/vocab/library'
 require 'ld4l/works_rdf/vocab/bf'
 require 'ld4l/works_rdf/version'
+require 'ld4l/foaf_rdf'
 
 
 module LD4L

--- a/lib/ld4l/works_rdf/models/bibframe/bibframe_identifier.rb
+++ b/lib/ld4l/works_rdf/models/bibframe/bibframe_identifier.rb
@@ -6,7 +6,8 @@ module LD4L
       @localname_prefix="i"
 
       configure :type => RDFVocabularies::BF.Identifier,
-                :base_uri => LD4L::WorksRDF.configuration.base_uri
+                :base_uri => LD4L::WorksRDF.configuration.base_uri,
+                :repository => :default
 
       property :identifier_scheme,  :predicate => RDFVocabularies::BF.identifierScheme  # uri
       property :identifier_value,   :predicate => RDFVocabularies::BF.identifierValue   # string

--- a/lib/ld4l/works_rdf/models/bibframe/bibframe_instance.rb
+++ b/lib/ld4l/works_rdf/models/bibframe/bibframe_instance.rb
@@ -6,7 +6,8 @@ module LD4L
       @localname_prefix="w"
 
       configure :type => RDFVocabularies::BF.Instance,
-                :base_uri => LD4L::WorksRDF.configuration.base_uri
+                :base_uri => LD4L::WorksRDF.configuration.base_uri,
+                :repository => :default
 
       property :instance_of,          :predicate => RDFVocabularies::BF.instanceOf,     :class_name => LD4L::WorksRDF::BibframeWork
       property :title,                :predicate => RDFVocabularies::BF.instanceTitle,  :class_name => LD4L::WorksRDF::BibframeTitle

--- a/lib/ld4l/works_rdf/models/bibframe/bibframe_organization.rb
+++ b/lib/ld4l/works_rdf/models/bibframe/bibframe_organization.rb
@@ -6,7 +6,8 @@ module LD4L
       @localname_prefix="w"
 
       configure :type => RDFVocabularies::BF.Organization,
-                :base_uri => LD4L::WorksRDF.configuration.base_uri
+                :base_uri => LD4L::WorksRDF.configuration.base_uri,
+                :repository => :default
 
       property :label,  :predicate => RDFVocabularies::BF.label  # string
 

--- a/lib/ld4l/works_rdf/models/bibframe/bibframe_person.rb
+++ b/lib/ld4l/works_rdf/models/bibframe/bibframe_person.rb
@@ -6,7 +6,8 @@ module LD4L
       @localname_prefix="p"
 
       configure :type => RDFVocabularies::BF.Person,
-                :base_uri => LD4L::WorksRDF.configuration.base_uri
+                :base_uri => LD4L::WorksRDF.configuration.base_uri,
+                :repository => :default
 
       property :label,  :predicate => RDFVocabularies::BF.label  # string
 

--- a/lib/ld4l/works_rdf/models/bibframe/bibframe_place.rb
+++ b/lib/ld4l/works_rdf/models/bibframe/bibframe_place.rb
@@ -6,7 +6,8 @@ module LD4L
       @localname_prefix="w"
 
       configure :type => RDFVocabularies::BF.Place,
-                :base_uri => LD4L::WorksRDF.configuration.base_uri
+                :base_uri => LD4L::WorksRDF.configuration.base_uri,
+                :repository => :default
 
       property :label,  :predicate => RDFVocabularies::BF.label  # string
 

--- a/lib/ld4l/works_rdf/models/bibframe/bibframe_provider.rb
+++ b/lib/ld4l/works_rdf/models/bibframe/bibframe_provider.rb
@@ -6,7 +6,8 @@ module LD4L
       @localname_prefix="p"
 
       configure :type => RDFVocabularies::BF.Provider,
-                :base_uri => LD4L::WorksRDF.configuration.base_uri
+                :base_uri => LD4L::WorksRDF.configuration.base_uri,
+                :repository => :default
 
       property :provider_date,  :predicate => RDFVocabularies::BF.providerDate    # string
       property :provider_name,  :predicate => RDFVocabularies::BF.providerName,  :class_name => LD4L::WorksRDF::BibframeOrganization    # string

--- a/lib/ld4l/works_rdf/models/bibframe/bibframe_title.rb
+++ b/lib/ld4l/works_rdf/models/bibframe/bibframe_title.rb
@@ -6,7 +6,8 @@ module LD4L
       @localname_prefix="t"
 
       configure :type => RDFVocabularies::BF.Title,
-                :base_uri => LD4L::WorksRDF.configuration.base_uri
+                :base_uri => LD4L::WorksRDF.configuration.base_uri,
+                :repository => :default
 
       property :title_value,  :predicate => RDFVocabularies::BF.titleValue  # string
       property :subtitle,     :predicate => RDFVocabularies::BF.subtitle    # string

--- a/lib/ld4l/works_rdf/models/bibframe/bibframe_work.rb
+++ b/lib/ld4l/works_rdf/models/bibframe/bibframe_work.rb
@@ -6,7 +6,8 @@ module LD4L
       @localname_prefix="w"
 
       configure :type => RDFVocabularies::BF.Work,
-                :base_uri => LD4L::WorksRDF.configuration.base_uri
+                :base_uri => LD4L::WorksRDF.configuration.base_uri,
+                :repository => :default
 
       property :creator,      :predicate => RDFVocabularies::BF.creator,      :class_name => LD4L::WorksRDF::BibframePerson
       property :contributor,  :predicate => RDFVocabularies::BF.contributor,  :class_name => LD4L::WorksRDF::BibframePerson

--- a/lib/ld4l/works_rdf/models/bibo/vivo_authorship.rb
+++ b/lib/ld4l/works_rdf/models/bibo/vivo_authorship.rb
@@ -6,7 +6,8 @@ module LD4L
       @localname_prefix="p"
 
       configure :type => RDFVocabularies::VIVO.Authorship,
-                :base_uri => LD4L::WorksRDF.configuration.base_uri
+                :base_uri => LD4L::WorksRDF.configuration.base_uri,
+                :repository => :default
 
       property :relates,   :predicate => RDFVocabularies::VIVO.relates,  :class_name => LD4L::WorksRDF::VivoBook
     end

--- a/lib/ld4l/works_rdf/models/bibo/vivo_book.rb
+++ b/lib/ld4l/works_rdf/models/bibo/vivo_book.rb
@@ -4,6 +4,10 @@ module LD4L
       class << self; attr_reader :localname_prefix end
       @localname_prefix="w"
 
+      configure :type => RDFVocabularies::VIVO.Book,
+                :base_uri => LD4L::WorksRDF.configuration.base_uri,
+                :repository => :default
+
       property :most_specific_type,   :predicate => RDFVocabularies::VITRO.mostSpecificType
       property :date_time_value,      :predicate => RDFVocabularies::VIVO.dateTimeValue,       :cast => false
       property :place_of_publication, :predicate => RDFVocabularies::VIVO.placeOfPublication

--- a/lib/ld4l/works_rdf/models/schema/oclc_schema_book.rb
+++ b/lib/ld4l/works_rdf/models/schema/oclc_schema_book.rb
@@ -5,6 +5,10 @@ module LD4L
       class << self; attr_reader :localname_prefix end
       @localname_prefix="w"
 
+      configure :type => RDF::SCHEMA.Book,
+                :base_uri => LD4L::WorksRDF.configuration.base_uri,
+                :repository => :default
+
       property :oclcnum,              :predicate => RDFVocabularies::LIBRARY.oclcnum
       property :place_of_publication, :predicate => RDFVocabularies::LIBRARY.placeOfPublication
     end

--- a/lib/ld4l/works_rdf/models/schema/schema_person.rb
+++ b/lib/ld4l/works_rdf/models/schema/schema_person.rb
@@ -6,7 +6,8 @@ module LD4L
       @localname_prefix="p"
 
       configure :type => RDFVocabularies::VIVO.Authorship,
-                :base_uri => LD4L::WorksRDF.configuration.base_uri
+                :base_uri => LD4L::WorksRDF.configuration.base_uri,
+                :repository => :default
 
       property :family_name,   :predicate => RDF::SCHEMA.familyName
       property :given_name,    :predicate => RDF::SCHEMA.givenName

--- a/lib/ld4l/works_rdf/models/schema/schema_publisher.rb
+++ b/lib/ld4l/works_rdf/models/schema/schema_publisher.rb
@@ -6,7 +6,8 @@ module LD4L
       @localname_prefix="p"
 
       configure :type => RDFVocabularies::BGN.Agent,
-                :base_uri => LD4L::WorksRDF.configuration.base_uri
+                :base_uri => LD4L::WorksRDF.configuration.base_uri,
+                :repository => :default
 
       property :publisher_name,   :predicate => RDF::SCHEMA.name
     end

--- a/lib/ld4l/works_rdf/models/work_metadata.rb
+++ b/lib/ld4l/works_rdf/models/work_metadata.rb
@@ -23,24 +23,39 @@ module LD4L
       attr_accessor :error
       attr_accessor :error_message
 
-      def initialize( the_work )
+      def initialize( the_work=nil )
+
+        # displayable:
+        #    line 1     @titla  @pubdate (year only)
+        #    line 2     @author
+        #    line 3     @format   @pub_info   @language   @edition
+        #    line 4     @local_location   @local_callnumber
+        # sortable:     @title, @author, @pub_date (year only)
+        # facetable:    @format, @author, @pub_date (year_only), @language, @subject, @subject_region, @subject_era, @genre, @fiction_or_non, @local_location, @local_callnumber
+
         @work_type        = :UNKNOWN
         @rdf_types        = ""
-        uri               = ""
-        @model            = ""
-        @title            = ""
-        @subtitle         = ""
-        @author           = ""
-        @pub_date         = ""
-        @pub_info         = ""
-        @language         = ""
-        @edition          = ""
-        @oclc_id          = ""
+        @uri              = ""    #             :displayable (used as URL for link)
+        @model            = ""    #             :stored
+        @title            = ""    #             :displayable, :searchable, :sortable
+        @subtitle         = ""    #             :displayable, :searchable
+        @author           = ""    # :facetable, :displayable, :searchable, :sortable
+        @pub_date         = ""    # :facetable, :displayable,              :sortable   (year only)
+        @pub_info         = ""    #             :displayable, :searchable
+        @language         = ""    # :facetable, :displayable
+        # @subject          = ""  # :facetable
+        # @subject_region   = ""  # :facetable
+        # @subject_era      = ""  # :facetable
+        # @genre            = ""  # :facetable
+        # @fiction_or_non   = ""  # :facetable
+        @edition          = ""    #             :displayable
+        @oclc_id          = ""    #             :displayable
         @source_id        = :UNKNOWN
         @source           = ""
         @local_id         = ""
-        @local_location   = ""
-        @local_callnumber = ""
+        @local_location   = ""    # :facetable
+        @local_callnumber = ""    # :facetable
+        @format           = ""    # :facetable, :displayable
         @error            = false
         @error_message    = ""
         unless the_work.nil?
@@ -50,6 +65,75 @@ module LD4L
             rdf_types << t.to_s
           end
         end
+      end
+
+      def generate_solr_doc
+        solr_doc = {}
+
+        solr_doc[:resource_title_ti]         = @title
+        solr_doc[:resource_title_sort_ss]    = @title
+        solr_doc[:resource_subtitle_ti]      = @subtitle
+        solr_doc[:resource_author_ti]        = @author
+        solr_doc[:resource_author_facet_sim] = @author
+        solr_doc[:resource_author_sort_ss]   = @author
+        # solr_doc[:resource_subject_tim]     = @subject
+        solr_doc[:resource_pub_date_iti]     = @pub_date      # year only, e.g.:  2005
+        solr_doc[:resource_pub_info]         = @pub_info      # format: "Champaign, IL :Human Kinetics, c2005."
+        solr_doc[:resource_language]         = @language
+        solr_doc[:resource_edition]          = @edition
+        solr_doc[:resource_oclc_id]          = @oclc_id
+        solr_doc[:resource_source_id]        = @source_id
+        solr_doc[:resource_source]           = @source
+        solr_doc[:resource_local_id]         = @local_id
+        solr_doc[:resource_local_location]   = @local_location
+        solr_doc[:resource_local_callnumber] = @local_callnumber
+        solr_doc[:resource_profile_ss]       = serialize
+        solr_doc
+      end
+
+      def load_from_solr_doc( solr_doc )
+        deserialize solr_doc[:resource_profile_ss]  if solr_doc.has_key? :resource_profile_ss
+      end
+
+      def serialize
+        attrs = {}
+        attrs[:title]            = @title
+        attrs[:subtitle]         = @subtitle
+        attrs[:author]           = @author
+        attrs[:pub_date]         = @pub_date
+        attrs[:pub_info]         = @pub_info
+        attrs[:language]         = @language
+        attrs[:edition]          = @edition
+        attrs[:oclc_id]          = @oclc_id
+        attrs[:source_id]        = @source_id
+        attrs[:source]           = @source
+        attrs[:local_id]         = @local_id
+        attrs[:local_location]   = @local_location
+        attrs[:local_callnumber] = @local_callnumber
+        attrs.to_json
+      end
+
+      def deserialize( serialization )
+        attrs = JSON.parse serialization
+
+        @title            = attrs["title"]
+        @subtitle         = attrs["subtitle"]
+        @author           = attrs["author"]
+        @pub_date         = attrs["pub_date"]
+        @pub_info         = attrs["pub_info"]
+        @language         = attrs["language"]
+        @edition          = attrs["edition"]
+        @oclc_id          = attrs["oclc_id"]
+        @source_id        = attrs["source_id"]
+        @source           = attrs["source"]
+        @local_id         = attrs["local_id"]
+        @local_location   = attrs["local_location"]
+        @local_callnumber = attrs["local_callnumber"]
+        self
+      end
+
+      def set_type(format)       # TODO validate format, don't just use it
+        @work_type = format.upcase.to_sym if format.is_a? String  # TODO sometimes format is an array (e.g. ["Thesis","Book"])
       end
 
       def set_type_to_book

--- a/lib/ld4l/works_rdf/services/get_metadata_from_solr_query.rb
+++ b/lib/ld4l/works_rdf/services/get_metadata_from_solr_query.rb
@@ -1,0 +1,29 @@
+module LD4L
+  module WorksRDF
+    class GetMetadataFromSolrQuery
+
+      ##
+      # Get display metadata via content negotiation from an Cornell Solr
+      #
+      # @param [String, RDF::URI] uri for the work
+      #
+      # @returns an instance of LD4L::WorksRDF::WorkMetadata populated with display metadata for the work located at the URI
+      def self.call( solr_query_url, solr_field_translations, localname_prefix="" )
+        raise ArgumentError, 'solr_query_url argument must be a uri string'  unless solr_query_url.kind_of?(String)
+
+        results  = LD4L::WorksRDF::GetSolrResultsFromSolrQuery.call(solr_query_url)
+        return LD4L::WorksRDF::SetErrorInMetadata.call(solr_query_url,'ERROR: Unable to retrieve SOLR documents from URI') unless results && results.size > 0
+
+        results_hash = Hash.from_xml(results)
+        solr_docs = results_hash["response"]["result"]["doc"]
+        solr_docs = [ solr_docs ] unless solr_docs.is_a? Array
+
+        metadata = []
+        solr_docs.each do |solr_doc|
+          metadata << LD4L::WorksRDF::GetMetadataFromSolrDoc.call(solr_doc, solr_field_translations)
+        end
+        metadata
+      end
+    end
+  end
+end

--- a/lib/ld4l/works_rdf/services/metadata_services/get_metadata_from_solr_doc.rb
+++ b/lib/ld4l/works_rdf/services/metadata_services/get_metadata_from_solr_doc.rb
@@ -1,0 +1,67 @@
+module LD4L
+  module WorksRDF
+    class GetMetadataFromSolrDoc
+
+      # TODO This is Cornell specific.  Need a general processor of solr OR a callback to an institution specific processor.
+      ##
+      # Get metadata from solr document.
+      #
+      # @param [Hash] solr document
+      # @param [Hash] translations identifying location in solr doc for metadata fields
+      #
+      # @returns an instance of one of the OCLC work models
+      def self.call( solr_doc, solr_field_translations )
+        flat_doc = flatten(solr_doc["arr"])
+        flat_doc.merge! interpret_str(solr_doc["str"])
+        metadata = self.populate_with_solr_values(flat_doc, solr_field_translations)
+        metadata
+      end
+
+      def self.populate_with_solr_values( solr_doc, solr_field_translations )
+        metadata = LD4L::WorksRDF::WorkMetadata.new()
+
+        metadata.source           = "Cornell Library"
+        metadata.set_source_to_cornell_library
+
+        # metadata.format           = solr_doc["format"].upcase.to_sym
+        metadata.set_type(solr_doc["format"])
+        metadata.local_id         = solr_doc["id"]
+        metadata.uri              = "https://newcatalog.library.cornell.edu/catalog/"+metadata.local_id
+        metadata.title            = solr_doc["title"]
+        metadata.author           = solr_doc["author"]
+        metadata.pub_date         = solr_doc["pub_date_display"]
+        metadata.pub_info         = solr_doc["pub_info_display"]
+        metadata.language         = solr_doc["language_display"]
+        metadata.edition          = solr_doc["edition_display"]
+
+        other_ids = solr_doc["other_id_display"]
+        oclc_id = nil
+        oclc_id = other_ids.select { |id| id.start_with? "(OCoLC)" } if other_ids.is_a? Array
+        oclc_id = oclc_id.first if (oclc_id.is_a? Array) && (oclc_id.size > 0)
+        oclc_id = other_ids if (other_ids.is_a? String) && (other_ids.start_with? "(OCoLC)")
+        metadata.oclc_id = oclc_id[7..-1] unless (oclc_id.nil?) || (!oclc_id.is_a? String)
+
+        metadata
+      end
+
+      def self.flatten( solr_doc )
+        flat_hash = {}
+        solr_doc.each do |h|
+          name = h["name"]
+          value = h["str"]
+          flat_hash[name] = value
+        end
+        flat_hash
+      end
+
+      def self.interpret_str( str_field )
+        flat_hash = {}
+        flat_hash["id"] = str_field.first
+        flat_hash["author"] = str_field[1] if str_field.size > 3
+        flat_hash["title"] = str_field.last
+        flat_hash
+      end
+
+    end
+  end
+end

--- a/lib/ld4l/works_rdf/services/negotiation_services/get_solr_results_from_solr_query.rb
+++ b/lib/ld4l/works_rdf/services/negotiation_services/get_solr_results_from_solr_query.rb
@@ -1,0 +1,35 @@
+module LD4L
+  module WorksRDF
+    class GetSolrResultsFromSolrQuery
+
+      ##
+      # Get solr documents populated from the solr query url via content negotiation.
+      #
+      # @param [String] solr_query_url for the work(s)
+      #
+      # @returns a string holding solr results which may include multiple solr documents
+      def self.call( solr_query_url )
+        raise ArgumentError, 'solr_query_url argument must be a uri string'  unless solr_query_url.kind_of?(String)
+
+        http = Curl.get(solr_query_url) do |curl|
+          curl.headers['Accept'] = 'application/xml'
+          curl.headers['Api-Version'] = '2.2'
+          curl.follow_location = true
+          curl.max_redirects = 3
+          curl.connect_timeout = 30
+          curl.useragent = "curb"
+        end
+        header = http.header_str
+
+        status = LD4L::WorksRDF::ResponseHeader.get_status(header)
+        raise EncodingError, "Status #{status} returned from query"  unless status == '200'
+
+        response_content_type = LD4L::WorksRDF::ResponseHeader.get_content_type(header)
+        raise EncodingError, "uri returned results of type '#{response_content_type}' instead of expected 'application/xml'"  unless response_content_type == 'application/xml'
+
+        results = http.body_str
+        results
+      end
+    end
+  end
+end

--- a/lib/ld4l/works_rdf/services/negotiation_services/response_header.rb
+++ b/lib/ld4l/works_rdf/services/negotiation_services/response_header.rb
@@ -9,12 +9,29 @@ module LD4L
         content_type
       end
 
+      def self.get_status( header )
+        parsed_header = self.parse(header)
+        parsed_header["Status"]
+      end
+
+      # "HTTP/1.1 400 Bad Request\r\n
+      # Date: Sat, 22 Aug 2015 18:49:49 GMT\r\n
+      # Last-Modified: Sat, 22 Aug 2015 18:49:49 GMT\r\n
+      # ETag: \"14f56bed06e\"\r\n
+      # Cache-Control: no-cache, no-store\r\n
+      # Pragma: no-cache\r\n
+      # Expires: Sat, 01 Jan 2000 01:00:00 GMT\r\n
+      # Content-Type: application/xml;charset=UTF-8\r\n
+      # Connection: close\r\n\r\n"
+
       def self.parse(header)
         parts_hash = {}
         parts_array = header.split("\r\n")
         parts_array.each do |p|
           match_data = p.match("(.*): (.*)")
           value = nil
+          field = "Status"        if p.start_with? "HTTP/1.1"
+          value = p[9..11]        if p.start_with? "HTTP/1.1"
           field = match_data[1]   if match_data && match_data.size > 1
           value = match_data[2]   if match_data && match_data.size > 2
           semicolon_split = value.split(";")  if value

--- a/spec/ld4l/works_rdf/configuration_spec.rb
+++ b/spec/ld4l/works_rdf/configuration_spec.rb
@@ -84,14 +84,6 @@ describe 'LD4L::WorksRDF' do
 
     describe "localname_minter" do
       context "when minter is nil" do
-        before do
-          class DummyWork < LD4L::WorksRDF::VivoBook
-            configure :type => RDFVocabularies::VIVO.Book, :base_uri => LD4L::WorksRDF.configuration.base_uri, :repository => :default
-          end
-        end
-        after do
-          Object.send(:remove_const, "DummyWork") if Object
-        end
         it "should use default minter in minter gem" do
           localname = ActiveTriples::LocalName::Minter.generate_local_name(
                   LD4L::WorksRDF::VivoBook, 10, {:prefix=>'default_'},

--- a/spec/ld4l/works_rdf/services/get_metadata_from_uri_spec.rb
+++ b/spec/ld4l/works_rdf/services/get_metadata_from_uri_spec.rb
@@ -13,20 +13,20 @@ describe 'LD4L::WorksRDF::GetMetadataFromURI' do
       # uri = "http://vivo.cornell.edu/individual/n56611/n56611.ttl"
       uri = "http://vivo.cornell.edu/individual/n56611"
       the_work = LD4L::WorksRDF::GetModelFromURI.call(uri)
-      the_metadata = LD4L::WorksRDF::GetMetadataFromURI.call(uri)
+      the_metadata = LD4L::WorksRDF::GetMetadataFromVivoURI.call(uri)
 
       expect(the_metadata).to be_kind_of LD4L::WorksRDF::WorkMetadata
       expect(the_metadata.work_type).to eq :BOOK
       expect(the_metadata.model).to be_kind_of LD4L::WorksRDF::VivoBook
       expect(the_metadata.rdf_types).to include RDFVocabularies::BIBO.Book
-      expect(the_metadata.title).to eq the_work.title.first
+      expect(the_metadata.title).to eq the_work.label.first
     end
 
     it "should return instance of SchemaWork when URI is from Worldcat OCLC" do
       # uri = "http://vivo.cornell.edu/individual/n56611/n56611.ttl"
       uri = "http://www.worldcat.org/oclc/276976"
       the_work = LD4L::WorksRDF::GetModelFromURI.call(uri)
-      the_metadata = LD4L::WorksRDF::GetMetadataFromURI.call(uri)
+      the_metadata = LD4L::WorksRDF::GetMetadataFromOclcURI.call(uri)
 
       expect(the_metadata).to be_kind_of LD4L::WorksRDF::WorkMetadata
       expect(the_metadata.work_type).to eq :BOOK


### PR DESCRIPTION
Fixes #1
- no longer inherits configure in ActiveTriples::Resource, so need to put in every resource class
- remove solrizer from tests
- add solr integration using active_triples-solrizer
- do not pin gems
- types are arrays at 0.8.2 and not arrays at < 0.8
- update travis to match ActiveTriples 0.8.2
- add badges to readme 
